### PR TITLE
Fixes in snippet file for creating an action. 

### DIFF
--- a/zf2helper-action.sublime-snippet
+++ b/zf2helper-action.sublime-snippet
@@ -1,12 +1,13 @@
 <snippet>
     <content><![CDATA[/**
- * ${3:undocumented action}
+ * ${1:undocumented action}
  *
- * @return <type>
+ * @return ${2:<type>}
  **/
-public function _NAME_Action()
+public function ${3:_NAME_}Action()
 {
-    return array("" => "")
+    ${4:return array("" => "")}
+    ${0:}
 }
 ]]></content>
     <tabTrigger>action</tabTrigger>


### PR DESCRIPTION
...w other elements such as return type in doctype, action name, and action body is selectable by pressing tab and cursor will jump right into proper place.
